### PR TITLE
Change the default time zone to UTC.

### DIFF
--- a/.templates/bazarr/service.yml
+++ b/.templates/bazarr/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - UMASK_SET=022 #optional
     volumes:
       - ./volumes/bazarr/config:/config

--- a/.templates/deluge/service.yml
+++ b/.templates/deluge/service.yml
@@ -5,7 +5,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - UMASK=022 #optional
       - DELUGE_LOGLEVEL=error #optional
     volumes:

--- a/.templates/emby/service.yml
+++ b/.templates/emby/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - UMASK_SET=022 #optional
     volumes:
       - ./volumes/emby/config:/config

--- a/.templates/embystat/service.yml
+++ b/.templates/embystat/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
     volumes:
       - ./volumes/embystat/config:/config
     ports:

--- a/.templates/jackett/service.yml
+++ b/.templates/jackett/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - AUTO_UPDATE=true #optional
       # - RUN_OPTS=<run options here> #optional
     volumes:

--- a/.templates/jellyfin/service.yml
+++ b/.templates/jellyfin/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - UMASK_SET=<022> #optional
     volumes:
       - ./volumes/jellyfin/config:/config

--- a/.templates/lidarr/service.yml
+++ b/.templates/lidarr/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - UMASK_SET=022 #optional
     volumes:
       - ./volumes/lidarr/config:/config

--- a/.templates/nginx/service.yml
+++ b/.templates/nginx/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
     volumes:
       - ./volumes/nginx/config:/config
     ports:

--- a/.templates/nzbget/service.yml
+++ b/.templates/nzbget/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
     volumes:
       - ./volumes/nzbget/config:/config
       - ./downloads:/downloads

--- a/.templates/radarr/service.yml
+++ b/.templates/radarr/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=0
       - PGID=0
-      - TZ=Europe/London
+      - TZ=UTC
       - UMASK=022 #optional
     volumes:
       - ./volumes/radarr/config:/config

--- a/.templates/sabznbd/service.yml
+++ b/.templates/sabznbd/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
     volumes:
       - ./volumes/sabnzbd/config:/config
       - ./downloads:/downloads

--- a/.templates/sonarr/service.yml
+++ b/.templates/sonarr/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - UMASK_SET=022 #optional
     volumes:
       - ./volumes/sonarr/data:/config

--- a/.templates/transmission/service.yml
+++ b/.templates/transmission/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       - TRANSMISSION_WEB_HOME=/combustion-release/ #optional
 #      - USER=username #optional
 #      - PASS=password #optional

--- a/.templates/tvheadend/service.yml
+++ b/.templates/tvheadend/service.yml
@@ -4,7 +4,7 @@
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=UTC
       #- RUN_OPTS=<run options here> #optional
     volumes:
       - ./volumes/tvheadend/config:/config


### PR DESCRIPTION
UTC is a good default time zone to set all services templates to since
it is the primary time standard with no offset.

Signed-off-by: Brandon Authier <histamineblkr@gmail.com>