### PR TITLE
Remove "function" Keyword for Portability

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -90,7 +90,7 @@ password_dialog() {
 command_exists() { command -v "$@" >/dev/null 2>&1 ; }
 
 #function copies the template yml file to the local service folder and appends to the docker-compose.yml file
-function yml_builder() {
+yml_builder() {
 
 	service="services/$1/service.yml"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -87,9 +87,7 @@ password_dialog() {
 }
 #test=$( password_dialog )
 
-function command_exists() {
-	command -v "$@" >/dev/null 2>&1
-}
+command_exists() { command -v "$@" >/dev/null 2>&1 ; }
 
 #function copies the template yml file to the local service folder and appends to the docker-compose.yml file
 function yml_builder() {


### PR DESCRIPTION
Removing the function keyword is better for portability, the POSIX standard, and clearer in code.